### PR TITLE
Remove invalid `pip install`

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -26,7 +26,6 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install .[docs]
-          pip install -r requirements-doc.txt
       - name: Build documentation
         run: |
           mkdocs gh-deploy --force


### PR DESCRIPTION
The workflow to publish the documentation currently contains a `pip install requirement-doc.txt` instruction, where `requirement-doc.txt` does not exist (requirements are in `pyproject.toml`). This PR removes this instruction. 