### PR TITLE
Provide generic `bos` and `eos` variables

### DIFF
--- a/docs/reference/dispatch.md
+++ b/docs/reference/dispatch.md
@@ -1,1 +1,24 @@
 # Model-based prompt dispatching
+
+
+Different models often require different prompts to achieve a given task. They are, in essence, not different prompts in the sense that they are supposed to perform the same operation. In the same way we use `functools.singledispatch` to dispatch a functionality on the type of the first
+argument, it can be useful to dispatch the prompt on the model that is being used.
+
+`prompts` provides a way to dispatch the prompt on the model:
+
+
+```python
+import prompts
+
+
+@prompts.template
+def a_simple_prompt(query: str):
+    """<s>{{ query }}</s>"""
+
+@a_simple_prompt.register("google/gemma-2-9b")
+def a_simple_prompt_gemma(query: str):
+    """<bos>{{ query }}<eos>"""
+```
+
+!!! note
+    Choosing BOS and EOS based on the model is better achieved by using [special variables](special_tokens.md).

--- a/docs/reference/special_tokens.md
+++ b/docs/reference/special_tokens.md
@@ -1,0 +1,31 @@
+# Handle special tokens
+
+Tokens that indicate the beginnning of a sequence, an end of sequence, that
+delineate user and assistant turns in a conversation, etc. are model-specific.
+This means that one needs to write a new prompt each time they use a new model,
+only replacing these special tokens. This is error-prone and leads to duplicated
+work.
+
+`prompts` provides special variables in its templates that allows user to use special tokens in their prompts in a model-agnotic way:
+
+```python
+import prompts
+
+
+@prompts.template
+def a_simple_prompt(query: str):
+    """{{ bos + query + eos }}"""
+
+
+print(a_simple_prompt["mistralai/Mistral-7B-v0.1"]("question"))
+# <s>question</s>
+
+print(a_simple_prompt["google/gemma-2-9b"]("question"))
+# <bos>question<eos>
+```
+
+
+!!! note "Registry"
+
+    The registry is currently limited to a few models. Please [open an issue](https://github.com/outlines-dev/prompts/issues) if you
+    want to use `prompts` with a model that is not currently in the registry.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,3 +75,4 @@ nav:
       - reference/index.md
       - Prompt template: reference/template.md
       - Dispatch: reference/dispatch.md
+      - Special tokens: reference/special_tokens.md

--- a/prompts/templates.py
+++ b/prompts/templates.py
@@ -37,6 +37,7 @@ class Template:
 
     template: str
     signature: inspect.Signature
+    model: Optional[str] = None
     registry: Dict[str, Callable] = field(default_factory=dict)
 
     def __call__(self, *args, **kwargs) -> str:
@@ -83,6 +84,7 @@ class Template:
 
         def wrapper(fn: Callable):
             tpl = template(fn)
+            tpl.model = model_name
             self.registry[model_name] = tpl
             return tpl
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -197,6 +197,10 @@ def test_dispatch():
     assert callable(simple_prompt)
     assert callable(simple_prompt["provider/name"])
 
+    assert simple_prompt.model is None
+    assert simple_prompt_name.model == "provider/name"
+    assert simple_prompt["provider/name"].model == "provider/name"
+
     assert simple_prompt("test") == "test"
     assert simple_prompt_name("test") == "name: test"
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -183,6 +183,7 @@ def test_no_prompt():
             return variable
 
 
+@pytest.mark.filterwarnings("ignore: The model")
 def test_dispatch():
 
     @prompts.template
@@ -207,3 +208,24 @@ def test_dispatch():
     assert simple_prompt("test") == "test"
     assert simple_prompt["gpt2"]("test") == "test"
     assert simple_prompt["provider/name"]("test") == "name: test"
+
+
+def test_special_tokens():
+
+    @prompts.template
+    def simple_prompt(query: str):
+        """{{ bos + query + eos }}"""
+
+    assert simple_prompt("test") == "test"
+    assert simple_prompt["openai-community/gpt2"]("test") == "test<|endoftext|>"
+    assert simple_prompt["mistralai/Mistral-7B-v0.1"]("test") == "<s>test</s>"
+
+
+def test_warn():
+
+    @prompts.template
+    def simple_prompt():
+        """test"""
+
+    with pytest.warns(UserWarning, match="not present in the special token"):
+        simple_prompt["non-existent-model"]()


### PR DESCRIPTION
This PR provides generic `bos` and `eos` variables that can be added to a prompt template and will be rendered correctly for the specified model. For instance:


```python
import prompts


@prompt.template
def simple_prompt(query: str):
    """{{ bos + query + eos}}"""


print(simple_prompt["mistralai/Mistral-7B-v0.1"]("test"))
# <s>test</s>
```

This begs a question: should we automatically add BOS tokens to prompt templates? My current inclination is to answer no: `@prompt.template` should give full control to the user over which tokens are used. We could, however, introduce a function that takes care of formatting the prompt correctly for non-chat workflows (which are handled via #4) and could handle common mistakes such as double BOS tokens.

Closes #2.