### PR TITLE
Automatically render user, assistant, system, special tokens

### DIFF
--- a/docs/reference/special_tokens.md
+++ b/docs/reference/special_tokens.md
@@ -6,6 +6,9 @@ This means that one needs to write a new prompt each time they use a new model,
 only replacing these special tokens. This is error-prone and leads to duplicated
 work.
 
+
+## Beginning and end of sequences
+
 `prompts` provides special variables in its templates that allows user to use special tokens in their prompts in a model-agnotic way:
 
 ```python
@@ -29,3 +32,21 @@ print(a_simple_prompt["google/gemma-2-9b"]("question"))
 
     The registry is currently limited to a few models. Please [open an issue](https://github.com/outlines-dev/prompts/issues) if you
     want to use `prompts` with a model that is not currently in the registry.
+
+
+## Chat and Instruct models
+
+`prompts` also provides special variables `user`, `assistant` and `system` that are related to chat workflows, so you can design prompts with a chat format in a model-agnostic way:
+
+```python
+import prompts
+
+
+@prompts.template
+def simple_prompt(favorite: str):
+    """{{ bos + user.begin}} What is your favorite {{favorite + '? ' + user.end}}
+    {{ assistant.begin }}
+    """
+```
+
+Chat templates are so idiosyncractic, however, that we recommend using the `Chat` class to format according to chat templates.

--- a/prompts/tokens.py
+++ b/prompts/tokens.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class Limits:
+    begin: str = ""
+    end: str = ""
+
+
+@dataclass
+class Special:
+    sequence: Limits = Limits("", "")
+    user: Limits = Limits("", "")
+    assistant: Limits = Limits("", "")
+    system: Limits = Limits("", "")
+
+
+SPECIAL_TOKENS: Dict[Optional[str], Special] = {
+    None: Special(),
+    "google/gemma-2-9b": Special(Limits("<bos>", "<eos>")),
+    "openai-community/gpt2": Special(Limits("", "<|endoftext|>")),
+    "mistralai/Mistral-7B-v0.1": Special(Limits("<s>", "</s>")),
+    "mistralai/Mistral-7B-Instruct-v0.1": Special(
+        Limits("<s>", "</s>"),
+        Limits("[INST]", "[/INST]"),
+        Limits("", "</s>"),
+    ),
+}

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,6 @@
+from prompts.tokens import Special
+
+
+def test_simple():
+    special = Special()
+    assert special.assistant.begin == ""


### PR DESCRIPTION
Follows #6 and closes #3. We introduce a new data structure to hold the models' special tokens.

Note that chat templates are so idiosyncratic that I am not sure this is going to be useful in practice. I should probably focus on #4.