### PR TITLE
Use default factories for dataclass attributes

### DIFF
--- a/prompts/tokens.py
+++ b/prompts/tokens.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Optional
 
 
@@ -10,10 +10,10 @@ class Limits:
 
 @dataclass
 class Special:
-    sequence: Limits = Limits("", "")
-    user: Limits = Limits("", "")
-    assistant: Limits = Limits("", "")
-    system: Limits = Limits("", "")
+    sequence: Limits = field(default_factory=lambda: Limits())
+    user: Limits = field(default_factory=lambda: Limits())
+    assistant: Limits = field(default_factory=lambda: Limits())
+    system: Limits = field(default_factory=lambda: Limits())
 
 
 SPECIAL_TOKENS: Dict[Optional[str], Special] = {


### PR DESCRIPTION
For Python > 3.11 dataclass field initial values are checked for mutability so we get a type error

```
tests/test_templates.py:3: in <module>
    import prompts
prompts/__init__.py:1: in <module>
    from .templates import template
prompts/templates.py:10: in <module>
    from prompts.tokens import SPECIAL_TOKENS, Special
prompts/tokens.py:11: in <module>
    @dataclass
../../.pyenv/versions/3.11.9/lib/python3.11/dataclasses.py:1232: in dataclass
    return wrap(cls)
../../.pyenv/versions/3.11.9/lib/python3.11/dataclasses.py:1222: in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
../../.pyenv/versions/3.11.9/lib/python3.11/dataclasses.py:958: in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
../../.pyenv/versions/3.11.9/lib/python3.11/dataclasses.py:815: in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
E   ValueError: mutable default <class 'prompts.tokens.Limits'> for field sequence is not allowed: use default_factory
```

This PR just adds those default factories.